### PR TITLE
Bump path-parse from 1.0.6 to 1.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3809,9 +3809,9 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-type": {
       "version": "3.0.0",


### PR DESCRIPTION
### Description

The changes in this pull request update the version of the `path-parse` package in the `package-lock.json` file from 1.0.6 to 1.0.7. This update includes changes to the resolved URL and integrity hash.

Summary of changes:
- Update `path-parse` package version from 1.0.6 to 1.0.7.
- Update the resolved URL to https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz.
- Update the integrity hash to sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==.