### PR TITLE
Bump ws from 5.2.2 to 5.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5090,9 +5090,9 @@
       }
     },
     "ws": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
+      "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
       "requires": {
         "async-limiter": "~1.0.0"
       }


### PR DESCRIPTION
### Description

In this pull request, the version of the "ws" package in the `package-lock.json` file is being updated from 5.2.2 to 5.2.3.

- Update the version of the "ws" package in `package-lock.json` from 5.2.2 to 5.2.3.
- Update the resolved URL link for the "ws" package to the latest version.
- Update the integrity checksum for the "ws" package to match the new version.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI



> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->